### PR TITLE
[WIP] Backtick escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,3 +199,33 @@ let x = 0.5
     @where(df, a >= $x)
 end
 ```
+
+## Backtick Syntax for Expressing Arbitrary Column Names
+
+As in SQL, Volcanito allows backticks to be used to indicate that an otherwise
+invalid identifier is a column name. This can be used when column names are
+derived from an expression without an alias:
+
+```
+import Pkg
+Pkg.activate(".")
+
+import DataFrames: DataFrame
+
+import Volcanito: @select, @aggregate_vector
+
+import Statistics: mean
+
+df = DataFrame(
+    a = rand(10_000),
+    b = rand(10_000),
+)
+
+@select(
+    @aggregate_vector(df, mean(a)),
+    `mean(a)` + 1,
+)
+```
+
+This trick means that the normal Julia syntax for generating a `Cmd` object is
+not available: use the `@cmd` macro instead to achieve the same effect.

--- a/docs/expression_rules.md
+++ b/docs/expression_rules.md
@@ -24,6 +24,7 @@ syntactic positions from being considered to refer to columns:
     is an `Expr` whose `head == :$`.
 5. The even-numbered positional arguments to a `comparison` expression are
     excluded. In Julia, this is an `Expr` whose `head == :comparison`.
+6. Any expression inside of backticks like `` `mean(col1)` `` is included.
 
 Whenever processing expressions, please process them in the order described
 above. It makes it easier to check completeness because you can treat the list

--- a/src/Volcanito.jl
+++ b/src/Volcanito.jl
@@ -17,6 +17,7 @@ import DataFrames
 import MacroTools: inexpr, postwalk
 import Printf: @printf
 
+include("query/expression_operations/remove_backticks.jl")
 include("query/expression_operations/validate.jl")
 include("query/expression_operations/get_alias.jl")
 include("query/expression_operations/find_column_names.jl")

--- a/src/query/expression_operations/find_column_names.jl
+++ b/src/query/expression_operations/find_column_names.jl
@@ -56,6 +56,8 @@ function _find_column_names!(
             end
         end
         column_names
+    elseif isa(e, Expr) && e.head == :macrocall && isa(e.args[1], GlobalRef) && e.args[1].name == Symbol("@cmd")
+        push!(column_names, Symbol(e.args[3]))
     elseif isa(e, Expr)
         for i in 1:length(e.args)
             _find_column_names!(e.args[i], column_names)

--- a/src/query/expression_operations/get_alias.jl
+++ b/src/query/expression_operations/get_alias.jl
@@ -39,10 +39,12 @@ julia> get_alias(:(x = a + sin(b)))
 function get_alias(@nospecialize(e::Any))::Tuple
     if isa(e, Expr) && e.head == :(=)
         alias, body = e.args[1], e.args[2]
+    elseif isa(e, Expr) && e.head == :macrocall && isa(e.args[1], GlobalRef) && e.args[1].name == Symbol("@cmd")
+        alias, body = Symbol(remove_backticks(Meta.parse(e.args[3]))), e
     else
-        alias, body = Symbol(e), e
+        alias, body = Symbol(remove_backticks(e)), e
     end
-    
+
     validate(body)
 
     alias, body
@@ -50,3 +52,9 @@ end
 
 # TODO: Document this.
 has_alias(e::Any) = isa(e, Expr) && e.head == :(=)
+
+# TODO: Document this.
+function aliased(e)
+    alias, body = get_alias(e)
+    Expr(:(=), alias, body)
+end

--- a/src/query/expression_operations/remove_backticks.jl
+++ b/src/query/expression_operations/remove_backticks.jl
@@ -1,0 +1,33 @@
+
+"""
+# Description
+
+Rewrite an expression to remove all use of backticks.
+
+# Arguments
+
+1. `e::Any`: An expression.
+
+# Return Values
+
+1. `e::Any`: An expression in which backticks have been removed.
+
+# Examples
+
+```
+julia> remove_backticks(:(`mean(a)`))
+:(mean(a))
+```
+"""
+function remove_backticks(@nospecialize(e::Any))
+    if isa(e, Expr) && e.head == :macrocall && isa(e.args[1], GlobalRef) && e.args[1].name == Symbol("@cmd")
+        Meta.parse(e.args[3])
+    elseif isa(e, Expr)
+        Expr(
+            e.head,
+            [remove_backticks(a) for a in e.args]...,
+        )
+    else
+        e
+    end
+end

--- a/src/query/expression_operations/rewrite_column_names.jl
+++ b/src/query/expression_operations/rewrite_column_names.jl
@@ -74,6 +74,8 @@ function rewrite_column_names(
             end
         end
         Expr(e.head, rewritten_args..., )
+    elseif isa(e, Expr) && e.head == :macrocall && isa(e.args[1], GlobalRef) && e.args[1].name == Symbol("@cmd")
+        Expr(:ref, tuple_name, index[Symbol(e.args[3])])
     elseif isa(e, Expr)
         rewritten_args = Any[]
         for i in 1:length(e.args)
@@ -85,6 +87,97 @@ function rewrite_column_names(
         Expr(e.head, rewritten_args...,)
     elseif isa(e, Symbol)
         Expr(:ref, tuple_name, index[e])
+    else
+        e
+    end
+end
+
+"""
+# Description
+
+Rewrite an expression written in terms of column names (represented as symbols)
+into an expression written in terms of safe column names (symbols from gensym
+calls).
+
+See docs/expression_rules.md for details.
+
+# Arguments
+
+1. `e::Any`: An expression.
+2. `mapping::Dict{Symbol, Symbol}`: A dictionary mapping symbols to symbols.
+
+# Return Values
+
+1. `e::Any`: An expression in which column name symbols are replaced by tuple
+    indexing expressions.
+
+# Examples
+
+```
+julia> rewrite_column_names_broadcast(
+    :(a + b),
+    Dict(:a => gensym(), :b => gensym()),
+)
+:(var"##256" + var"##257")
+```
+"""
+function rewrite_column_names_broadcast(
+    @nospecialize(e::Any),
+    mapping::Dict{Symbol, Symbol},
+)
+    if isa(e, Expr) && e.head == :(=)
+        Expr(
+            :(=),
+            e.args[1],
+            rewrite_column_names_broadcast(e.args[2], mapping),
+        )
+    elseif isa(e, Expr) && e.head == :kw
+        Expr(
+            :kw,
+            e.args[1],
+            rewrite_column_names_broadcast(e.args[2], mapping),
+        )
+    elseif isa(e, Expr) && e.head == :call
+        rewritten_args = Any[]
+        for i in 2:length(e.args)
+            push!(
+                rewritten_args,
+                rewrite_column_names_broadcast(e.args[i], mapping),
+            )
+        end
+        Expr(
+            :call,
+            e.args[1],
+            rewritten_args...,
+        )
+    elseif isa(e, Expr) && e.head == :$
+        e
+    elseif isa(e, Expr) && e.head == :comparison
+        rewritten_args = Any[]
+        for i in 1:length(e.args)
+            if i % 2 == 1
+                push!(
+                    rewritten_args,
+                    rewrite_column_names_broadcast(e.args[i], mapping),
+                )
+            else
+                push!(rewritten_args, e.args[i])
+            end
+        end
+        Expr(e.head, rewritten_args..., )
+    elseif isa(e, Expr) && e.head == :macrocall && isa(e.args[1], GlobalRef) && e.args[1].name == Symbol("@cmd")
+        mapping[Symbol(e.args[3])]
+    elseif isa(e, Expr)
+        rewritten_args = Any[]
+        for i in 1:length(e.args)
+            push!(
+                rewritten_args,
+                rewrite_column_names_broadcast(e.args[i], mapping),
+            )
+        end
+        Expr(e.head, rewritten_args...,)
+    elseif isa(e, Symbol)
+        mapping[e]
     else
         e
     end

--- a/src/query/macros/aggregate_vector.jl
+++ b/src/query/macros/aggregate_vector.jl
@@ -3,7 +3,6 @@ macro aggregate_vector(src, exprs...)
     all_column_names = Set{Symbol}()
 
     for expr in exprs
-        @assert has_alias(expr)
         alias, body = get_alias(expr)
         push!(all_column_names, find_column_names(body)...)
     end
@@ -20,7 +19,10 @@ macro aggregate_vector(src, exprs...)
 
     aggregates_tuple_expr = Expr(
         :tuple,
-        map(e -> esc(e), exprs)...,
+        map(
+            e -> esc(aliased(e)),
+            exprs,
+        )...,
     )
 
     quote


### PR DESCRIPTION
This implements the first part of https://github.com/johnmyleswhite/Volcanito.jl/issues/18. It is now possible to do things like:

```
@select(
    @aggregate_vector(df, mean(a)),
    `mean(a)` + 1,
)
```

Still need to implement combination of backticks and interpolation syntax.